### PR TITLE
FUI-99 - Added whitespace pre to preserve whitespace in certain areas:

### DIFF
--- a/css/themes/tooling.css
+++ b/css/themes/tooling.css
@@ -2290,6 +2290,7 @@ th {
 .table-bordered > tbody > tr > td,
 .table-bordered > tfoot > tr > td {
   border: 1px solid #dddddd;
+  white-space: pre;
 }
 .table-bordered > thead > tr > th,
 .table-bordered > thead > tr > td {
@@ -2465,6 +2466,9 @@ table th[class*="col-"] {
   .table-responsive > .table-bordered > tfoot > tr:last-child > td {
     border-bottom: 0;
   }
+}
+.mw-tiles-item-header > h4 {
+  white-space: pre;
 }
 fieldset {
   padding: 0;

--- a/js/components/content.tsx
+++ b/js/components/content.tsx
@@ -98,9 +98,6 @@ class Content extends React.Component<IComponentProps, IContentState> {
             relative_urls: false,
             remove_script_host : false,
 
-            // entity_encoding: 'named',
-            // entities: '160,nbsp',
-
             setup: (editor) => {
                 this.editor = editor;
                 const props = this.props;
@@ -293,15 +290,11 @@ class Content extends React.Component<IComponentProps, IContentState> {
             state.contentValue
             ? state.contentValue 
             : model.contentValue || '';
-
-        const removeAllSpaces = string => string.indexOf(' ') !== -1 ?
-            removeAllSpaces(string.replace(' ', '&nbsp;')) :
-            string;
         
         const openBracket = '{![';
         const closedBracket = ']}';
 
-        const removeSpacesInReferences = contentValue.split(openBracket).map((splitByStartString, index) => {
+        const replaceSpacesInReferences = contentValue.split(openBracket).map((splitByStartString, index) => {
             // splitByStartString is all text up until the next {![
             // e.g. {![ , 'ReferencedValue]} normal text in the content' , {![
             // If this text has index:0, then this text didn't have a start {![ OR
@@ -311,7 +304,8 @@ class Content extends React.Component<IComponentProps, IContentState> {
                 return splitByStartString;
             }
             const splitByEndString = splitByStartString.split(closedBracket);
-            splitByEndString[0] = removeAllSpaces(splitByEndString[0]);
+            // Using regex to replace spaces with &nbsp;
+            splitByEndString[0] = splitByEndString[0].replace(/ /g, '&nbsp;');
             return splitByEndString.join(closedBracket);
         }).join(openBracket);
         
@@ -321,7 +315,7 @@ class Content extends React.Component<IComponentProps, IContentState> {
             maxLength: model.maxSize,
             cols: model.width,
             rows: model.height,
-            value: removeSpacesInReferences,
+            value: replaceSpacesInReferences,
             readOnly: model.isEditable === false,
             disabled: model.isEnabled === false,
             required: model.isRequired === true,

--- a/js/components/content.tsx
+++ b/js/components/content.tsx
@@ -98,6 +98,9 @@ class Content extends React.Component<IComponentProps, IContentState> {
             relative_urls: false,
             remove_script_host : false,
 
+            // entity_encoding: 'named',
+            // entities: '160,nbsp',
+
             setup: (editor) => {
                 this.editor = editor;
                 const props = this.props;
@@ -291,13 +294,34 @@ class Content extends React.Component<IComponentProps, IContentState> {
             ? state.contentValue 
             : model.contentValue || '';
 
+        const removeAllSpaces = string => string.indexOf(' ') !== -1 ?
+            removeAllSpaces(string.replace(' ', '&nbsp;')) :
+            string;
+        
+        const openBracket = '{![';
+        const closedBracket = ']}';
+
+        const removeSpacesInReferences = contentValue.split(openBracket).map((splitByStartString, index) => {
+            // splitByStartString is all text up until the next {![
+            // e.g. {![ , 'ReferencedValue]} normal text in the content' , {![
+            // If this text has index:0, then this text didn't have a start {![ OR
+            // If this text has no ending ]}
+            if (index === 0 || splitByStartString.indexOf(closedBracket) === -1) {
+                // Then this is not a valid reference, so we will leave it alone
+                return splitByStartString;
+            }
+            const splitByEndString = splitByStartString.split(closedBracket);
+            splitByEndString[0] = removeAllSpaces(splitByEndString[0]);
+            return splitByEndString.join(closedBracket);
+        }).join(openBracket);
+        
         const props: any = {
             id: this.id,
             placeholder: model.hintValue,
             maxLength: model.maxSize,
             cols: model.width,
             rows: model.height,
-            value: contentValue,
+            value: removeSpacesInReferences,
             readOnly: model.isEditable === false,
             disabled: model.isEnabled === false,
             required: model.isRequired === true,
@@ -320,6 +344,8 @@ class Content extends React.Component<IComponentProps, IContentState> {
         const outcomeButtons = outcomes && outcomes.map((outcome) => {
             return <Outcome id={outcome.id} flowKey={this.props.flowKey} />;
         });
+
+
 
         return <div className={className} id={this.props.id}>
             <label>


### PR DESCRIPTION
in tiles item headers so Flow names preserve whitespace
in table row data so Page/Value/Type/Service/ names preserve whitespace
When TinyMCE receices stored text, now it receives value references with '&nbsp;' so whitespace is preserved