### PR TITLE
FUI-41 - Do not bind onChange when the toggle isn't editable

### DIFF
--- a/js/components/toggle.tsx
+++ b/js/components/toggle.tsx
@@ -73,7 +73,9 @@ class Toggle extends React.Component<IComponentProps, IToggleState> {
         };
 
         if (!this.props.isDesignTime) {
-            props.onChange = this.handleChange;
+            if (model.isEditable) {
+                props.onChange = this.handleChange;
+            }
             props.onBlur = this.handleEvent;
         }
 


### PR DESCRIPTION
This fixes the toggle being editable regardless of the setting: isEditable