### PR TITLE
Feature/fui 333 select duplicates

### DIFF
--- a/js/components/select.tsx
+++ b/js/components/select.tsx
@@ -4,7 +4,6 @@ import { MultiSelect, SimpleSelect } from 'react-selectize';
 import registeredComponents from '../constants/registeredComponents';
 import IItemsComponentProps from '../interfaces/IItemsComponentProps';
 import { getOutcome } from './outcome';
-import { unionWith, path, eqBy } from 'ramda';
 
 import '../../css/select.less';
 
@@ -76,8 +75,12 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
             }
 
             if (state && state.objectData) {
-                // Replace 'selected' item in the option list. Match on `externalId` because the internalId is volatile
-                options = unionWith(eqBy(path(['value', 'externalId'])), this.getOptions(state.objectData), options);
+                // Replace 'selected' item(s) from `this.getOptions()`, in the `options` list.
+                // Match on `externalId` or the `internalId` because when offline there is no externalId
+                options = options
+                    .map(option => this.getOptions(state.objectData)
+                        .find(selection => (selection.value.externalId && selection.value.externalId === option.value.externalId) ||
+                                            selection.value.internalId === option.value.internalId) || option);
             }
 
             this.setState({ options });

--- a/js/components/select.tsx
+++ b/js/components/select.tsx
@@ -4,6 +4,7 @@ import { MultiSelect, SimpleSelect } from 'react-selectize';
 import registeredComponents from '../constants/registeredComponents';
 import IItemsComponentProps from '../interfaces/IItemsComponentProps';
 import { getOutcome } from './outcome';
+import { unionWith, path, eqBy } from 'ramda';
 
 import '../../css/select.less';
 
@@ -75,14 +76,8 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
             }
 
             if (state && state.objectData) {
-
-                const selectedOptions = state.objectData.filter(
-                    item => options.find(option => option.value.internalId === item.internalId),
-                );
-
-                if (selectedOptions.length === 0) {
-                    options = (this.getOptions(state.objectData) || []).concat(options);
-                }
+                // Replace 'selected' item in the option list. Match on `externalId` because the internalId is volatile
+                options = unionWith(eqBy(path(['value', 'externalId'])), this.getOptions(state.objectData), options);
             }
 
             this.setState({ options });
@@ -257,7 +252,6 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
         const Outcome = getOutcome();
 
         manywho.log.info(`Rendering Select: ${this.props.id}, ${model.developerName}`);
-        console.log(this.props, this.state.options);
 
         const state =
             this.props.isDesignTime ?
@@ -312,7 +306,6 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
                     internalIds = this.props.objectData.filter(item => item.isSelected)
                         .map(item => item.internalId);
                 }
-
                 let values = null;
 
                 if (internalIds && internalIds.length > 0) {

--- a/js/components/select.tsx
+++ b/js/components/select.tsx
@@ -7,7 +7,7 @@ import { getOutcome } from './outcome';
 
 import '../../css/select.less';
 
-declare var manywho: any;
+declare const manywho: any;
 
 interface IDropDownState {
     options?: any[];
@@ -35,53 +35,117 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
         this.debouncedOnSearch = manywho.utils.debounce(this.props.onSearch, 750);
     }
 
-    getOptions(objectData) {
+    componentWillMount() {
+        this.setState({ options: this.getOptions(this.props.objectData || []) });
+        window.addEventListener('blur', this.onWindowBlur);
+    }
+
+    componentDidMount() {
+        (findDOMNode(this) as HTMLElement).querySelector('input').classList.add('prevent-submit-on-enter');
+    }
+
+    componentWillReceiveProps(nextProps) {
         const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
-        const columns = manywho.component.getDisplayColumns(model.columns);
+        const state = manywho.state.getComponent(this.props.id, this.props.flowKey);
 
-        if (columns && columns.length > 0) {
-            const columnTypeElementPropertyId = columns[0].typeElementPropertyId;
+        const doneLoading = this.props.isLoading && !nextProps.isLoading;
+        const hasRequest = model.objectDataRequest !== null || model.fileDataRequest !== null;
 
-            return objectData.map((item) => {
+        if ((doneLoading || !hasRequest) && nextProps.objectData && !nextProps.isDesignTime) {
+            let options = [];
 
-                const labelProperty = item.properties.find((value) => { 
-                    return manywho.utils.isEqual(
-                        value.typeElementPropertyId, 
-                        columnTypeElementPropertyId, 
-                        true,
-                    ); 
+            if (
+                nextProps.page > 1 &&
+                this.state.options.length < nextProps.limit * nextProps.page
+            ) {
+                options = this.state.options.concat(this.getOptions(nextProps.objectData));
+                this.setState({ isOpen: true });
+
+                const index = this.state.options.length + 1;
+
+                setTimeout(() => {
+                    const dropdown: HTMLDivElement =
+                        (findDOMNode(this) as HTMLDivElement)
+                            .querySelector('.dropdown-menu');
+                    const scrollTarget = dropdown.children.item(index) as HTMLElement;
+                    dropdown.scrollTop = scrollTarget.offsetTop;
                 });
+            } else {
+                options = this.getOptions(nextProps.objectData);
+            }
 
-                if (!labelProperty) {
-                    console.error(
-                        `columnTypeElementPropertyId ${columnTypeElementPropertyId} cannot be found in objectData item:`, 
-                        item,
-                    );
+            if (state && state.objectData) {
+
+                const selectedOptions = state.objectData.filter(
+                    item => options.find(option => option.value.internalId === item.internalId),
+                );
+
+                if (selectedOptions.length === 0) {
+                    options = (this.getOptions(state.objectData) || []).concat(options);
                 }
+            }
 
-                const optionText = labelProperty
-                    ? manywho.formatting.format(
-                        labelProperty.contentValue,
-                        labelProperty.contentFormat,
-                        labelProperty.contentType,
-                        this.props.flowKey,
-                    )
-                    : '';
-
-                return { 
-                    value: item, 
-                    label: optionText,
-                };
-            });
+            this.setState({ options });
         }
+
+        if (!this.props.isLoading && nextProps.isLoading) {
+            this.setState({ isOpen: false });
+        }
+
+        if (
+            this.props.isLoading &&
+            !nextProps.isLoading &&
+            !manywho.utils.isNullOrWhitespace(this.state.search)
+        ) {
+            this.setState({ isOpen: true });
+        }
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (!prevState.isOpen && this.state.isOpen) {
+
+            // Timeout to ensure the dropdown has had a chance to render before accessing it's child elements
+            setTimeout(
+                () => {
+                    const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
+                    const element = (findDOMNode(this) as HTMLElement);
+
+                    if (
+                        model.attributes &&
+                        manywho.utils.isEqual(model.attributes.isTethered, 'true', true)
+                    ) {
+                        const dropdown: HTMLElement =
+                            document.querySelector('.tether-element .dropdown-menu') as HTMLElement;
+
+                        const selectize: HTMLElement =
+                            element.querySelector('.react-selectize') as HTMLElement;
+
+                        if (dropdown !== null) {
+                            dropdown.addEventListener('scroll', this.isScrollLimit);
+                            dropdown.style.setProperty('width', `${selectize.offsetWidth}px`);
+                        }
+
+                    } else {
+                        element.querySelector('.dropdown-menu')
+                            .addEventListener('scroll', this.isScrollLimit);
+                    }
+                },
+                10,
+            );
+        }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('blur', this.onWindowBlur);
     }
 
     onValueChange(option) {
         if (!this.props.isLoading) {
-            if (option)
+            if (option) {
                 this.props.select(option.value);
-            else
+            } else {
                 this.props.clearSelection();
+            }
 
             this.setState({ isOpen: false });
         }
@@ -106,21 +170,68 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
     }
 
     onOpenChange(isOpen) {
-        if (!this.props.isLoading)
+        if (!this.props.isLoading) {
             this.setState({ isOpen });
+        }
     }
 
     onFocus() {
-        if (!this.props.isLoading)
+        if (!this.props.isLoading) {
             this.setState({ isOpen: true });
+        }
     }
 
     onBlur() {
         this.setState({ isOpen: false });
     }
 
-    filterOptions(options, search) {
-        return options;
+    onWindowBlur = (e) => {
+        if (this && this.refs && this.refs['select']) {
+            (this.refs['select'] as any).blur();
+        }
+    }
+
+    getOptions(objectData) {
+        const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
+        const columns = manywho.component.getDisplayColumns(model.columns);
+
+        if (columns && columns.length > 0) {
+            const columnTypeElementPropertyId = columns[0].typeElementPropertyId;
+
+            return objectData.map((item) => {
+
+                const labelProperty = item.properties.find((value) => {
+                    return manywho.utils.isEqual(
+                        value.typeElementPropertyId,
+                        columnTypeElementPropertyId,
+                        true,
+                    );
+                });
+
+                if (!labelProperty) {
+                    manywho.log.error(
+                        `columnTypeElementPropertyId ${columnTypeElementPropertyId} cannot be found in objectData item:`,
+                        item,
+                    );
+                }
+
+                const optionText = labelProperty
+                    ? manywho.formatting.format(
+                        labelProperty.contentValue,
+                        labelProperty.contentFormat,
+                        labelProperty.contentType,
+                        this.props.flowKey,
+                    )
+                    : '';
+
+                return {
+                    value: item,
+                    label: optionText,
+                };
+            });
+        }
+
+        return [];
     }
 
     getUid(option) {
@@ -129,118 +240,15 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
 
     isScrollLimit(e) {
         if (
-            e.target.offsetHeight + e.target.scrollTop >= e.target.scrollHeight && 
+            e.target.offsetHeight + e.target.scrollTop >= e.target.scrollHeight &&
             this.props.hasMoreResults
         ) {
             this.props.onNext();
         }
     }
 
-    onWindowBlur = (e) => {
-        if (this && this.refs && this.refs['select'])
-            (this.refs['select'] as any).blur();
-    }
-
-    componentWillReceiveProps(nextProps) {
-        const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
-        const state = manywho.state.getComponent(this.props.id, this.props.flowKey);
-
-        const doneLoading = this.props.isLoading && !nextProps.isLoading;
-        const hasRequest = model.objectDataRequest !== null || model.fileDataRequest !== null;
-
-        if ((doneLoading || !hasRequest) && nextProps.objectData && !nextProps.isDesignTime) {
-            let options = [];
-
-            if (
-                nextProps.page > 1 && 
-                this.state.options.length < nextProps.limit * nextProps.page
-            ) {
-                options = this.state.options.concat(this.getOptions(nextProps.objectData)),
-                    this.setState({ isOpen: true });
-
-                const index = this.state.options.length + 1;
-
-                setTimeout(() => {
-                    const dropdown : HTMLDivElement = 
-                        (findDOMNode(this) as HTMLDivElement)
-                        .querySelector('.dropdown-menu');
-                    const scrollTarget = dropdown.children.item(index) as HTMLElement;
-                    dropdown.scrollTop = scrollTarget.offsetTop;
-                });
-            } else {
-                options = this.getOptions(nextProps.objectData);
-            }
-
-            if (state && state.objectData) {
-
-                const selectedOptions = state.objectData.filter(
-                    item => options.find(option => option.value.internalId === item.internalId),
-                );
-
-                if (selectedOptions.length === 0)
-                    options = (this.getOptions(state.objectData) || []).concat(options);
-            }
-
-            this.setState({ options });
-        }
-
-        if (!this.props.isLoading && nextProps.isLoading)
-            this.setState({ isOpen: false });
-
-        if (
-            this.props.isLoading && 
-            !nextProps.isLoading && 
-            !manywho.utils.isNullOrWhitespace(this.state.search)
-        ) {
-            this.setState({ isOpen: true });
-        }
-    }
-
-    componentWillMount() {
-        this.setState({ options: this.getOptions(this.props.objectData || []) });
-        window.addEventListener('blur', this.onWindowBlur);
-    }
-
-    componentDidMount() {
-        (findDOMNode(this) as HTMLElement).querySelector('input').classList.add('prevent-submit-on-enter');
-    }
-
-    componentWillUnMount() {
-        window.removeEventListener('blur', this.onWindowBlur);
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        if (!prevState.isOpen && this.state.isOpen) {
-
-            // Timeout to ensure the dropdown has had a chance to render before accessing it's child elements
-            setTimeout(
-                () => {
-                    const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
-                    const element = (findDOMNode(this) as HTMLElement);
-
-                    if (
-                        model.attributes && 
-                        manywho.utils.isEqual(model.attributes.isTethered, 'true', true)
-                    ) {
-                        const dropdown: HTMLElement = 
-                            document.querySelector('.tether-element .dropdown-menu') as HTMLElement;
-
-                        const selectize: HTMLElement = 
-                            element.querySelector('.react-selectize') as HTMLElement;
-                        
-                        if (dropdown !== null) {
-                            dropdown.addEventListener('scroll', this.isScrollLimit);
-                            dropdown.style.setProperty('width', selectize.offsetWidth + 'px');
-                        }
-
-                    } else {
-                        element.querySelector('.dropdown-menu')
-                            .addEventListener('scroll', this.isScrollLimit);
-                    }
-                },
-                10,
-            );
-        }
+    filterOptions(options) {
+        return options;
     }
 
     render() {
@@ -249,11 +257,12 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
         const Outcome = getOutcome();
 
         manywho.log.info(`Rendering Select: ${this.props.id}, ${model.developerName}`);
+        console.log(this.props, this.state.options);
 
-        const state = 
-            this.props.isDesignTime ? 
-            { error: null, loading: null } :
-            manywho.state.getComponent(this.props.id, this.props.flowKey) || {};
+        const state =
+            this.props.isDesignTime ?
+                { error: null, loading: null } :
+                manywho.state.getComponent(this.props.id, this.props.flowKey) || {};
 
         const props: any = {
             filterOptions: this.filterOptions,
@@ -287,7 +296,7 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
             }
 
             if (
-                model.attributes && 
+                model.attributes &&
                 manywho.utils.isEqual(model.attributes.isTethered, 'true', true)
             ) {
                 props.tether = true;
@@ -297,48 +306,52 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
 
                 let internalIds = null;
 
-                if (state && state.objectData)
+                if (state && state.objectData) {
                     internalIds = state.objectData.map(item => item.internalId);
-                else
+                } else {
                     internalIds = this.props.objectData.filter(item => item.isSelected)
                         .map(item => item.internalId);
+                }
 
                 let values = null;
 
-                if (internalIds && internalIds.length > 0)
-                    values = 
-                        this.state.options
-                        .filter(option => internalIds.indexOf(option.value.internalId) !== -1);
+                if (internalIds && internalIds.length > 0) {
+                    values = this.state.options.filter(option => internalIds.indexOf(option.value.internalId) !== -1);
+                }
 
-                if (values)
+                if (values) {
                     if (!model.isMultiSelect) {
                         props.value = values[0];
                     } else {
                         props.values = values;
                         props.anchor = values[values.length - 1];
                     }
+                }
             }
         }
 
-        const selectElement = 
-            model.isMultiSelect ? 
-            <MultiSelect {...props} /> : 
-            <SimpleSelect {...props} />;
+        const selectElement =
+            model.isMultiSelect ?
+                <MultiSelect {...props} /> :
+                <SimpleSelect {...props} />;
 
         let refreshButton = null;
         if (model.objectDataRequest || model.fileDataRequest) {
             let className = 'glyphicon glyphicon-refresh';
 
             let isDisabled = false;
-            if (model.isEnabled === false || this.props.isLoading || model.isEditable === false)
+            if (model.isEnabled === false || this.props.isLoading || model.isEditable === false) {
                 isDisabled = true;
+            }
 
-            if (this.props.isLoading)
+            if (this.props.isLoading) {
                 className += ' spin';
+            }
 
             refreshButton = (
-                <button className="btn btn-default refresh-button" 
-                    onClick={this.props.refresh} 
+                <button
+                    className="btn btn-default refresh-button"
+                    onClick={this.props.refresh}
                     disabled={isDisabled}>
                     <span className={className} />
                 </button>
@@ -350,48 +363,52 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
         );
 
         let className = manywho.styling.getClasses(
-            this.props.parentId, 
-            this.props.id, 
-            'select', 
+            this.props.parentId,
+            this.props.id,
+            'select',
             this.props.flowKey,
         ).join(' ');
 
         className += ' form-group';
 
-        if (model.isVisible === false)
+        if (model.isVisible === false) {
             className += ' hidden';
+        }
 
-        if (model.isValid === false || state.isValid === false || state.error)
+        if (model.isValid === false || state.isValid === false || state.error) {
             className += ' has-error';
+        }
 
         const style: any = {};
         let widthClassName = null;
 
         if (model.width && model.width > 0) {
-            style.width = model.width + 'px';
+            style.width = `${model.width}px`;
             style.minWidth = style.width;
             widthClassName = 'width-specified';
         }
 
-        return <div className={className} id={this.props.id}>
-            <label>
-                {model.label}
-                {(model.isRequired) ? <span className="input-required"> * </span> : null}
-            </label>
-            <div style={style} className={widthClassName}>
-                {selectElement}
-                {refreshButton}
+        return (
+            <div className={className} id={this.props.id}>
+                <label>
+                    {model.label}
+                    {(model.isRequired) ? <span className="input-required"> * </span> : null}
+                </label>
+                <div style={style} className={widthClassName}>
+                    {selectElement}
+                    {refreshButton}
+                </div>
+                <span className="help-block">
+                    {
+                        (state.error && state.error.message) ||
+                        model.validationMessage ||
+                        state.validationMessage
+                    }
+                </span>
+                <span className="help-block">{model.helpInfo}</span>
+                {outcomeButtons}
             </div>
-            <span className="help-block">
-            {
-                (state.error && state.error.message) || 
-                model.validationMessage || 
-                state.validationMessage
-            }
-            </span>
-            <span className="help-block">{model.helpInfo}</span>
-            {outcomeButtons}
-        </div>;
+        );
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10587,7 +10587,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/prelude-extension/-/prelude-extension-0.1.0.tgz",
             "integrity": "sha1-5TMLalE9P8n4H7BLgm8BIHypAow=",
-            "dev": true,
             "requires": {
                 "prelude-ls": "^1.1.2"
             }
@@ -10595,8 +10594,7 @@
         "prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-            "dev": true
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "pretty-format": {
             "version": "24.8.0",
@@ -10948,7 +10946,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/react-selectize/-/react-selectize-3.0.1.tgz",
             "integrity": "sha512-dT53g7iCbSY7BSSXbgnGsufhfboA/5sL1a1LkvbYTup3lN0rvXWnUP9mQX6Scey46kLEa5oIV35Fn+YKxG8tqA==",
-            "dev": true,
             "requires": {
                 "prelude-extension": "^0.1.0",
                 "prelude-ls": "^1.1.1",
@@ -12555,10 +12552,9 @@
             }
         },
         "tether": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.6.tgz",
-            "integrity": "sha512-TyWPw9O0ExqH9/ZBnQ0P1/mNI6LX16YPx5XvixC/ZvAqMkhGeXmKTTsMbSBn3ViOrPuQi/Uef11bVp3sd5UcQQ==",
-            "dev": true
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.7.tgz",
+            "integrity": "sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw=="
         },
         "text-table": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "react-dropzone": "4.2.10",
         "react-maskedinput": "4.0.1",
         "react-motion": "0.5.2",
-        "react-selectize": "3.0.1",
         "react-test-renderer": "16.8.6",
         "react-transition-group": "1.2.1",
         "script-loader": "0.7.2",
@@ -124,6 +123,7 @@
         "mini-css-extract-plugin": "0.5.0",
         "ramda": "0.25.0",
         "react": "16.8.6",
-        "react-dom": "16.8.6"
+        "react-dom": "16.8.6",
+        "react-selectize": "3.0.1"
     }
 }


### PR DESCRIPTION
Due to a change several months ago for offline (?) the Select control now performs matches on the internalId of the option rather than the externalId.

However when the component updates the internalIds change and so the test to check for the selected item always failed and appended the existing options to the selected option(s), causing a duplicate.

The fix ensures the array merge between the two option lists removes duplicates based on the static externalId, rather than the volatile internalId