### PR TITLE
FUI-413: Disable tile animation for tooling only

### DIFF
--- a/css/themes/mw-tooling.less
+++ b/css/themes/mw-tooling.less
@@ -208,4 +208,11 @@
     .react-selectize.default {
         font-family: 'Open Sans', sans-serif;
     }
+
+    // FUI-413: Override the default tile animation only for tooling.
+    .mw-tiles-item-container {
+        .back {
+            transform: none !important;
+        }
+    }
 }


### PR DESCRIPTION
New solution using a LESS override for tooling only.