### PR TITLE
Feature/fui 436 table header sorting

### DIFF
--- a/__tests__/items-container.test.tsx
+++ b/__tests__/items-container.test.tsx
@@ -908,14 +908,17 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount();
         const objectData = Object.assign([], sortingTestData);
 
+        // The compare() method treats 'true' as true and any other value as false, so only two unique values
+        // are sorted which means the result of sorting these three rows is non-deterministic
+        // All 'true' values should be first for an ASC sort and last for a DESC sort.
         objectData.sort(componentWrapper.instance().compare('boolean', false));
-        expect(objectData[0].properties[0].contentValue).toEqual('false');
-        expect(objectData[1].properties[0].contentValue).toEqual('');
+        expect(['false', '']).toContain(objectData[0].properties[0].contentValue);
+        expect(['false', '']).toContain(objectData[1].properties[0].contentValue);
         expect(objectData[2].properties[0].contentValue).toEqual('true');
         objectData.sort(componentWrapper.instance().compare('boolean', true));
         expect(objectData[0].properties[0].contentValue).toEqual('true');
-        expect(objectData[1].properties[0].contentValue).toEqual('false');
-        expect(objectData[2].properties[0].contentValue).toEqual('');
+        expect(['false', '']).toContain(objectData[1].properties[0].contentValue);
+        expect(['false', '']).toContain(objectData[2].properties[0].contentValue);
     });
 
     test('Verify sort method handles contentType:encrypted', () => {

--- a/__tests__/items-container.test.tsx
+++ b/__tests__/items-container.test.tsx
@@ -12,8 +12,8 @@ describe('ItemsContainer component behaviour', () => {
     const globalAny:any = global;
 
     function manyWhoMount({
-        id = str(), 
-        parentId = str(), 
+        id = str(),
+        parentId = str(),
         flowKey = str(),
         isDesignTime = false,
         objectData = [],
@@ -59,7 +59,7 @@ describe('ItemsContainer component behaviour', () => {
     test('Component gets registered', () => {
         componentWrapper = manyWhoMount();
         expect(globalAny.window.manywho.component.register)
-        .toHaveBeenCalledWith('mw-items-container', ItemsContainer); 
+        .toHaveBeenCalledWith('mw-items-container', ItemsContainer);
     });
 
     test('areBulkActionsDefined returns true when bulk actions present', () => {
@@ -93,17 +93,17 @@ describe('ItemsContainer component behaviour', () => {
             componentType,
         });
 
-        expect(globalAny.window.manywho.component.getByName).toHaveBeenCalledWith(`mw-${componentType}`); 
+        expect(globalAny.window.manywho.component.getByName).toHaveBeenCalledWith(`mw-${componentType}`);
     });
 
     test('Empty items element is rendered when objectData is empty array', () => {
-        
+
         globalAny.window.manywho.component.getDisplayColumns = () => [{}];
 
         componentWrapper = manyWhoMount({
             objectData: [],
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 contentElement: expect.objectContaining({
@@ -112,18 +112,18 @@ describe('ItemsContainer component behaviour', () => {
                     }),
                 }),
             }),
-        ); 
+        );
 
     });
 
     test('Error element is rendered when no display columns have been defined', () => {
-        
+
         globalAny.window.manywho.component.getDisplayColumns = () => [];
 
         componentWrapper = manyWhoMount({
             objectData: [],
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 contentElement: expect.objectContaining({
@@ -132,7 +132,7 @@ describe('ItemsContainer component behaviour', () => {
                     }),
                 }),
             }),
-        ); 
+        );
 
     });
 
@@ -145,7 +145,7 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount({
             objectData: [],
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 contentElement: expect.objectContaining({
@@ -154,7 +154,7 @@ describe('ItemsContainer component behaviour', () => {
                     }),
                 }),
             }),
-        ); 
+        );
 
     });
 
@@ -166,12 +166,12 @@ describe('ItemsContainer component behaviour', () => {
             objectData: [],
             paginationSize: 23,
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 limit: 23,
             }),
-        ); 
+        );
 
     });
 
@@ -183,12 +183,12 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount({
             objectData: [],
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 limit: 16,
             }),
-        ); 
+        );
 
     });
 
@@ -202,12 +202,12 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount({
             id, parentId, flowKey, isDesignTime,
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 id, parentId, flowKey, isDesignTime,
             }),
-        ); 
+        );
     });
 
     test('isLoading is correctly passed to child component', () => {
@@ -215,12 +215,12 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount({
             loading: true,
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 isLoading: true,
             }),
-        ); 
+        );
     });
 
     test('Page number is correctly passed to child component', () => {
@@ -228,12 +228,12 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount({
             page: 42,
         });
-        
+
         expect(componentWrapper.find(Dynamic).prop('props')).toEqual(
             expect.objectContaining({
                 page: 42,
             }),
-        ); 
+        );
     });
 
     test('sort method updates state.sortedBy property', () => {
@@ -252,7 +252,7 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount({
             objectDataRequest: {},
         });
-        
+
         const testString = str(5);
 
         expect(componentWrapper.state().sortedIsAscending).toBe(null);
@@ -266,16 +266,20 @@ describe('ItemsContainer component behaviour', () => {
         expect(componentWrapper.state().sortedIsAscending).toBe(false);
     });
 
-    test('sort method logs an error when ObjectDataRequest is null', () => {
+    test('sort method toggles state.sortedIsAscending property when ObjectDataRequest is null', () => {
         componentWrapper = manyWhoMount({
             objectDataRequest: null,
         });
 
         const testString = str(5);
 
-        componentWrapper.instance().sort(testString);
+        expect(componentWrapper.state().sortedIsAscending).toBe(null);
 
-        expect(globalAny.window.manywho.log.error).toBeCalledWith(expect.any(String));
+        componentWrapper.instance().sort(testString);
+        expect(componentWrapper.state().sortedIsAscending).toBe(true);
+
+        componentWrapper.instance().sort(testString);
+        expect(componentWrapper.state().sortedIsAscending).toBe(false);
     });
 
     test('search method resets sorting state', () => {
@@ -323,7 +327,7 @@ describe('ItemsContainer component behaviour', () => {
             expect.anything(),
         );
     });
-    
+
     test('component.onOutcome gets called within instance onOutcome method', () => {
         componentWrapper = manyWhoMount();
 
@@ -334,24 +338,24 @@ describe('ItemsContainer component behaviour', () => {
 
         expect(globalAny.window.manywho.component.onOutcome).toBeCalled();
     });
-    
+
     test('load method calls manywho.engine.objectDataRequest if model.objectDataRequest is present', () => {
         componentWrapper = manyWhoMount({
             objectDataRequest: {},
         });
 
         componentWrapper.instance().load();
-        
+
         expect(globalAny.window.manywho.engine.objectDataRequest).toBeCalled();
     });
-    
+
     test('load method calls manywho.engine.fileDataRequest if model.fileDataRequest is present', () => {
         componentWrapper = manyWhoMount({
             fileDataRequest: {},
         });
 
         componentWrapper.instance().load();
-        
+
         expect(globalAny.window.manywho.engine.fileDataRequest).toBeCalled();
     });
 
@@ -359,7 +363,7 @@ describe('ItemsContainer component behaviour', () => {
         componentWrapper = manyWhoMount();
 
         const forceUpdateSpy = jest.spyOn(componentWrapper.instance(), 'forceUpdate');
-        
+
         componentWrapper.instance().load();
 
         expect(forceUpdateSpy).toBeCalled();
@@ -367,11 +371,11 @@ describe('ItemsContainer component behaviour', () => {
 
     test('onNext calls onPaginate with next page number', () => {
         const onPaginateSpy = jest.spyOn(ItemsContainer.prototype, 'onPaginate');
-        
+
         componentWrapper = manyWhoMount();
 
         globalAny.window.manywho.state.getComponent = () => ({ page: 3 });
-        
+
         componentWrapper.instance().onNext();
 
         expect(onPaginateSpy).toBeCalledWith(4);
@@ -379,11 +383,11 @@ describe('ItemsContainer component behaviour', () => {
 
     test('onPrev calls onPaginate with previous page number', () => {
         const onPaginateSpy = jest.spyOn(ItemsContainer.prototype, 'onPaginate');
-        
+
         componentWrapper = manyWhoMount();
 
         globalAny.window.manywho.state.getComponent = () => ({ page: 3 });
-        
+
         componentWrapper.instance().onPrev();
 
         expect(onPaginateSpy).toBeCalledWith(2);
@@ -391,11 +395,11 @@ describe('ItemsContainer component behaviour', () => {
 
     test('onFirstPage calls onPaginate with 1', () => {
         const onPaginateSpy = jest.spyOn(ItemsContainer.prototype, 'onPaginate');
-        
+
         componentWrapper = manyWhoMount();
 
         globalAny.window.manywho.state.getComponent = () => ({ page: 3 });
-        
+
         componentWrapper.instance().onFirstPage();
 
         expect(onPaginateSpy).toBeCalledWith(1);

--- a/__tests__/items-container.test.tsx
+++ b/__tests__/items-container.test.tsx
@@ -184,7 +184,7 @@ describe('ItemsContainer component behaviour', () => {
                 {
                     contentFormat: '',
                     contentType: 'ContentBoolean',
-                    contentValue: '',
+                    contentValue: 'false',
                     developerName: 'boolean',
                     objectData: null,
                 },
@@ -298,7 +298,7 @@ describe('ItemsContainer component behaviour', () => {
                 {
                     contentFormat: '',
                     contentType: 'ContentBoolean',
-                    contentValue: 'true',
+                    contentValue: '',
                     developerName: 'boolean',
                     objectData: null,
                 },
@@ -808,7 +808,7 @@ describe('ItemsContainer component behaviour', () => {
                 ],
             },
         ];
-        const objectData = Object.assign(single);
+        const objectData = Object.assign([], single);
 
         objectData.sort(componentWrapper.instance().compare('stuff', true));
         expect(objectData).toEqual(single);
@@ -818,7 +818,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Sanity check for our test sorting data', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         expect(objectData.length).toEqual(3);
         expect(objectData[0].order).toEqual(0);
@@ -828,7 +828,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Unknown sort key leaves order intact', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         objectData.sort(componentWrapper.instance().compare('no such key', true));
         expect(objectData[0].order).toEqual(0);
@@ -842,7 +842,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:string', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         objectData.sort(componentWrapper.instance().compare('string', false));
         expect(objectData[0].order).toEqual(2);
@@ -858,7 +858,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:password', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         objectData.sort(componentWrapper.instance().compare('password', false));
         expect(objectData[0].order).toEqual(2);
@@ -874,7 +874,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:datetime', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         objectData.sort(componentWrapper.instance().compare('datetime', false));
         expect(objectData[0].order).toEqual(2);
@@ -890,7 +890,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:number', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         objectData.sort(componentWrapper.instance().compare('number', false));
         expect(objectData[0].order).toEqual(2);
@@ -906,22 +906,21 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:boolean', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         objectData.sort(componentWrapper.instance().compare('boolean', false));
-        // Only two unique values so the result of sorting three rows is non-deterministic
-        expect(objectData[0].properties[0].contentValue).toEqual('');
-        expect(objectData[1].properties[0].contentValue).toEqual('true');
+        expect(objectData[0].properties[0].contentValue).toEqual('false');
+        expect(objectData[1].properties[0].contentValue).toEqual('');
         expect(objectData[2].properties[0].contentValue).toEqual('true');
         objectData.sort(componentWrapper.instance().compare('boolean', true));
         expect(objectData[0].properties[0].contentValue).toEqual('true');
-        expect(objectData[1].properties[0].contentValue).toEqual('true');
+        expect(objectData[1].properties[0].contentValue).toEqual('false');
         expect(objectData[2].properties[0].contentValue).toEqual('');
     });
 
     test('Verify sort method handles contentType:encrypted', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         // Nothing should happen as we can not sort this type of data
         objectData.sort(componentWrapper.instance().compare('encrypted', false));
@@ -932,7 +931,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:list', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         // Nothing should happen as we can not compare lists
         objectData.sort(componentWrapper.instance().compare('list', false));
@@ -943,7 +942,7 @@ describe('ItemsContainer component behaviour', () => {
 
     test('Verify sort method handles contentType:object', () => {
         componentWrapper = manyWhoMount();
-        const objectData = Object.assign(sortingTestData);
+        const objectData = Object.assign([], sortingTestData);
 
         // Nothing should happen as we can not compare user defined objects
         objectData.sort(componentWrapper.instance().compare('object', false));

--- a/__tests__/items-container.test.tsx
+++ b/__tests__/items-container.test.tsx
@@ -44,8 +44,381 @@ describe('ItemsContainer component behaviour', () => {
             loading, page,
         });
 
+        globalAny.window.manywho.component.contentTypes = {
+            string: 'CONTENTSTRING',
+            number: 'CONTENTNUMBER',
+            boolean: 'CONTENTBOOLEAN',
+            password: 'CONTENTPASSWORD',
+            datetime: 'CONTENTDATETIME',
+            content: 'CONTENTCONTENT',
+            object: 'CONTENTOBJECT',
+            list: 'CONTENTLIST',
+        };
+
         return mount(<ItemsContainer {...props} />);
     }
+
+    // Three rows of sortable data. Each row has a different ContentType with the
+    // developerName's of 'boolean', 'datetime', 'encrypted', 'list', 'number', 'object',
+    // 'password' and 'string'
+    const sortingTestData = [
+        {
+            developerName: 'OneOfEach',
+            isSelected: false,
+            order: 0,
+            properties: [
+                {
+                    contentFormat: '',
+                    contentType: 'ContentBoolean',
+                    contentValue: 'true',
+                    developerName: 'boolean',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentContent',
+                    contentValue: '<p>a content</p>',
+                    developerName: 'content',
+                    objectData: null,
+                },
+                {
+                    contentFormat: 'dd/MM/yyyy',
+                    contentType: 'ContentDateTime',
+                    contentValue: '2019-05-06T16:38:00+01:00',
+                    developerName: 'datetime',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentEncrypted',
+                    contentValue: null,
+                    developerName: 'encrypted',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentList',
+                    contentValue: null,
+                    developerName: 'list',
+                    objectData: [
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '1',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '2',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentNumber',
+                    contentValue: '1',
+                    developerName: 'number',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentObject',
+                    contentValue: null,
+                    developerName: 'object',
+                    objectData: [
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '10',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentPassword',
+                    contentValue: 'a password',
+                    developerName: 'password',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentString',
+                    contentValue: 'a string',
+                    developerName: 'string',
+                    objectData: null,
+                },
+            ],
+        },
+        {
+            developerName: 'OneOfEach',
+            isSelected: false,
+            order: 1,
+            properties: [
+                {
+                    contentFormat: '',
+                    contentType: 'ContentBoolean',
+                    contentValue: '',
+                    developerName: 'boolean',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentContent',
+                    contentValue: '<p>b content</p>',
+                    developerName: 'content',
+                    objectData: null,
+                },
+                {
+                    contentFormat: 'dd/MM/yyyy',
+                    contentType: 'ContentDateTime',
+                    contentValue: '2019-10-06T16:38:00+01:00',
+                    developerName: 'datetime',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentEncrypted',
+                    contentValue: null,
+                    developerName: 'encrypted',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentList',
+                    contentValue: null,
+                    developerName: 'list',
+                    objectData: [
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '2',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '3',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentNumber',
+                    contentValue: '2',
+                    developerName: 'number',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentObject',
+                    contentValue: null,
+                    developerName: 'object',
+                    objectData: [
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '11',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentPassword',
+                    contentValue: 'b password',
+                    developerName: 'password',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentString',
+                    contentValue: 'b string',
+                    developerName: 'string',
+                    objectData: null,
+                },
+            ],
+        },
+        {
+            developerName: 'OneOfEach',
+            isSelected: false,
+            order: 2,
+            properties: [
+                {
+                    contentFormat: '',
+                    contentType: 'ContentBoolean',
+                    contentValue: 'true',
+                    developerName: 'boolean',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentContent',
+                    contentValue: '<p>c content</p>',
+                    developerName: 'content',
+                    objectData: null,
+                },
+                {
+                    contentFormat: 'dd/MM/yyyy',
+                    contentType: 'ContentDateTime',
+                    contentValue: '2020-05-06T16:38:00+01:00',
+                    developerName: 'datetime',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentEncrypted',
+                    contentValue: null,
+                    developerName: 'encrypted',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentList',
+                    contentValue: null,
+                    developerName: 'list',
+                    objectData: [
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '4',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '5',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '6',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentNumber',
+                    contentValue: '3',
+                    developerName: 'number',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentObject',
+                    contentValue: null,
+                    developerName: 'object',
+                    objectData: [
+                        {
+                            developerName: 'SimpleDimple',
+                            isSelected: false,
+                            order: 0,
+                            properties: [
+                                {
+                                    contentFormat: '',
+                                    contentType: 'ContentString',
+                                    contentValue: '12',
+                                    developerName: 'simple',
+                                    objectData: null,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentPassword',
+                    contentValue: 'c password',
+                    developerName: 'password',
+                    objectData: null,
+                },
+                {
+                    contentFormat: '',
+                    contentType: 'ContentString',
+                    contentValue: 'c string',
+                    developerName: 'string',
+                    objectData: null,
+                },
+            ],
+        },
+    ];
 
     afterEach(() => {
         componentWrapper.unmount();
@@ -59,7 +432,7 @@ describe('ItemsContainer component behaviour', () => {
     test('Component gets registered', () => {
         componentWrapper = manyWhoMount();
         expect(globalAny.window.manywho.component.register)
-        .toHaveBeenCalledWith('mw-items-container', ItemsContainer);
+            .toHaveBeenCalledWith('mw-items-container', ItemsContainer);
     });
 
     test('areBulkActionsDefined returns true when bulk actions present', () => {
@@ -405,4 +778,177 @@ describe('ItemsContainer component behaviour', () => {
         expect(onPaginateSpy).toBeCalledWith(1);
     });
 
+    test('Check sorting empty array does not crash', () => {
+        componentWrapper = manyWhoMount();
+
+        const empty = [];
+        empty.sort(componentWrapper.instance().compare('', true));
+        expect(empty.length).toBe(0);
+
+        empty.sort(componentWrapper.instance().compare('', false));
+        expect(empty.length).toBe(0);
+    });
+
+    test('Check sorting a single item does nothing', () => {
+        componentWrapper = manyWhoMount();
+
+        const single = [
+            {
+                developerName: 'OneRow',
+                isSelected: false,
+                order: 0,
+                properties: [
+                    {
+                        contentFormat: '',
+                        contentType: 'ContentString',
+                        contentValue: 'my value',
+                        developerName: 'stuff',
+                        objectData: null,
+                    },
+                ],
+            },
+        ];
+        const objectData = Object.assign(single);
+
+        objectData.sort(componentWrapper.instance().compare('stuff', true));
+        expect(objectData).toEqual(single);
+        objectData.sort(componentWrapper.instance().compare('descending stuff', false));
+        expect(objectData).toEqual(single);
+    });
+
+    test('Sanity check for our test sorting data', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        expect(objectData.length).toEqual(3);
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+    });
+
+    test('Unknown sort key leaves order intact', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        objectData.sort(componentWrapper.instance().compare('no such key', true));
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+        objectData.sort(componentWrapper.instance().compare('no such key', false));
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+    });
+
+    test('Verify sort method handles contentType:string', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        objectData.sort(componentWrapper.instance().compare('string', false));
+        expect(objectData[0].order).toEqual(2);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(0);
+        objectData.sort(componentWrapper.instance().compare('string', true));
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+
+        expect(objectData).toEqual(sortingTestData);
+    });
+
+    test('Verify sort method handles contentType:password', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        objectData.sort(componentWrapper.instance().compare('password', false));
+        expect(objectData[0].order).toEqual(2);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(0);
+        objectData.sort(componentWrapper.instance().compare('password', true));
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+
+        expect(objectData).toEqual(sortingTestData);
+    });
+
+    test('Verify sort method handles contentType:datetime', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        objectData.sort(componentWrapper.instance().compare('datetime', false));
+        expect(objectData[0].order).toEqual(2);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(0);
+        objectData.sort(componentWrapper.instance().compare('datetime', true));
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+
+        expect(objectData).toEqual(sortingTestData);
+    });
+
+    test('Verify sort method handles contentType:number', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        objectData.sort(componentWrapper.instance().compare('number', false));
+        expect(objectData[0].order).toEqual(2);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(0);
+        objectData.sort(componentWrapper.instance().compare('number', true));
+        expect(objectData[0].order).toEqual(0);
+        expect(objectData[1].order).toEqual(1);
+        expect(objectData[2].order).toEqual(2);
+
+        expect(objectData).toEqual(sortingTestData);
+    });
+
+    test('Verify sort method handles contentType:boolean', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        objectData.sort(componentWrapper.instance().compare('boolean', false));
+        // Only two unique values so the result of sorting three rows is non-deterministic
+        expect(objectData[0].properties[0].contentValue).toEqual('');
+        expect(objectData[1].properties[0].contentValue).toEqual('true');
+        expect(objectData[2].properties[0].contentValue).toEqual('true');
+        objectData.sort(componentWrapper.instance().compare('boolean', true));
+        expect(objectData[0].properties[0].contentValue).toEqual('true');
+        expect(objectData[1].properties[0].contentValue).toEqual('true');
+        expect(objectData[2].properties[0].contentValue).toEqual('');
+    });
+
+    test('Verify sort method handles contentType:encrypted', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        // Nothing should happen as we can not sort this type of data
+        objectData.sort(componentWrapper.instance().compare('encrypted', false));
+        expect(objectData).toEqual(sortingTestData);
+        objectData.sort(componentWrapper.instance().compare('encrypted', true));
+        expect(objectData).toEqual(sortingTestData);
+    });
+
+    test('Verify sort method handles contentType:list', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        // Nothing should happen as we can not compare lists
+        objectData.sort(componentWrapper.instance().compare('list', false));
+        expect(objectData).toEqual(sortingTestData);
+        objectData.sort(componentWrapper.instance().compare('list', true));
+        expect(objectData).toEqual(sortingTestData);
+    });
+
+    test('Verify sort method handles contentType:object', () => {
+        componentWrapper = manyWhoMount();
+        const objectData = Object.assign(sortingTestData);
+
+        // Nothing should happen as we can not compare user defined objects
+        objectData.sort(componentWrapper.instance().compare('object', false));
+        expect(objectData).toEqual(sortingTestData);
+        objectData.sort(componentWrapper.instance().compare('object', true));
+        expect(objectData).toEqual(sortingTestData);
+    });
 });

--- a/js/components/items-container.tsx
+++ b/js/components/items-container.tsx
@@ -354,6 +354,11 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
                 objectData = model.objectData;
             }
 
+            // Sort the filtered list before slicing
+            if (this.state.sortedBy) {
+                objectData.sort(this.compare(this.state.sortedBy, this.state.sortedIsAscending));
+            }
+
             if (
                 model.attributes.pagination &&
                 manywho.utils.isEqual(model.attributes.pagination, 'true', true) &&
@@ -377,11 +382,6 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
                     hasMoreResults = (page * limit) + limit + 1 <= objectData.length;
                     objectData = objectData.slice(page * limit, (page * limit) + limit);
                 }
-            }
-
-            // Finally sort the filtered and sliced list
-            if (this.state.sortedBy) {
-                objectData.sort(this.compare(this.state.sortedBy, this.state.sortedIsAscending));
             }
 
         } else if (model.objectDataRequest || model.fileDataRequest) {

--- a/js/components/items-container.tsx
+++ b/js/components/items-container.tsx
@@ -161,7 +161,7 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
      */
     compare(sortedBy, sortedIsAscending) {
 
-        return function callback(a, b) {
+        return (a, b) => {
 
             const l = a.properties.find(item => item.developerName === sortedBy);
             const r = b.properties.find(item => item.developerName === sortedBy);
@@ -184,9 +184,9 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
                 if (checkBooleanString(l.contentValue) === checkBooleanString(r.contentValue)) {
                     result = 0;
                 } else if (checkBooleanString(l.contentValue) && !checkBooleanString(r.contentValue)) {
-                    result = 1;
-                } else {
                     result = -1;
+                } else {
+                    result = 1;
                 }
                 break;
 
@@ -194,7 +194,6 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
                 result = 0;
                 break;
             }
-
 
             return (sortedIsAscending ? result : (result * -1));
         };
@@ -333,12 +332,11 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
         if (!model.objectDataRequest && !model.fileDataRequest) {
 
             if (!manywho.utils.isNullOrWhitespace(state.search)) {
-                objectData = model.objectData.filter((item) => {
-                    return item.properties.filter((prop) => {
-                        const matchingColumns = columns.filter((column) => {
-                            return column.typeElementPropertyId === prop.typeElementPropertyId &&
-                                column.isDisplayValue;
-                        });
+                objectData = model.objectData.filter(
+                    item => item.properties.filter((prop) => {
+                        const matchingColumns = columns.filter(
+                            column => column.typeElementPropertyId === prop.typeElementPropertyId && column.isDisplayValue,
+                        );
 
                         if (matchingColumns && matchingColumns.length > 0 && prop.contentValue) {
                             return manywho.formatting.format(
@@ -350,8 +348,8 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
                         }
 
                         return false;
-                    }).length > 0;
-                });
+                    }).length > 0,
+                );
             } else {
                 objectData = model.objectData;
             }


### PR DESCRIPTION
Added functionality to sort list tables when clicking on the header.

1st commit is just linting.

Because the data from the list is not received from an API but from within the flow, sorting has been implemented as client-side sorting.

Sorting is performed on the temporary object after filtering and before pagination has been applied to ensure the 'global' model is not modified causing any side affects.

Tests supplied.