### PR TITLE
FUI-459: Fix broken Format menu in tinyMCE

### DIFF
--- a/js/components/content.tsx
+++ b/js/components/content.tsx
@@ -82,7 +82,8 @@ class Content extends React.Component<IComponentProps, IContentState> {
             file_picker_callback: null,
             convert_urls: false,
             relative_urls: false,
-            remove_script_host : false,
+            remove_script_host: false,
+            importcss_append: true,
 
             setup: (editor) => {
                 this.editor = editor;


### PR DESCRIPTION
Gottcha with tinyMCE, you have to have `importcss_append:true` for the styleselect Format menu to work.

