### PR TITLE
FLOW-504 - corrected case for adding autocomplete to datetime inputs

### DIFF
--- a/js/components/input-datetime.tsx
+++ b/js/components/input-datetime.tsx
@@ -211,7 +211,7 @@ class InputDateTime extends React.Component<IInputProps, null> {
             disabled={this.props.disabled}
             required={this.props.required}
             onBlur={this.props.onBlur}
-            autoComplete={this.props.autocomplete} />;
+            autoComplete={this.props.autoComplete} />;
     }
 
 }


### PR DESCRIPTION
simply the data coming in was being capitalised and then the renderer was using lower case, I think they all might be the same...