### PR TITLE
FLOW-407: Now bundling TinyMCE into the build output

### DIFF
--- a/js/components/content.tsx
+++ b/js/components/content.tsx
@@ -1,36 +1,44 @@
 import * as React from 'react';
+import * as tinymce from 'tinymce';
 import registeredComponents from '../constants/registeredComponents';
 import IComponentProps from '../interfaces/IComponentProps';
 import outcome from './outcome';
 import tableContainer from './table-container';
 import fileUpload from './file-upload';
 import '../../css/content.less';
+import 'tinymce/skins/lightgray/skin.min.css';
+import 'tinymce/themes/modern';
+import 'tinymce/plugins/anchor';
+import 'tinymce/plugins/autolink';
+import 'tinymce/plugins/advlist';
+import 'tinymce/plugins/charmap';
+import 'tinymce/plugins/code';
+import 'tinymce/plugins/contextmenu';
+import 'tinymce/plugins/directionality';
+import 'tinymce/plugins/emoticons';
+import 'tinymce/plugins/fullscreen';
+import 'tinymce/plugins/hr';
+import 'tinymce/plugins/importcss';
+import 'tinymce/plugins/image';
+import 'tinymce/plugins/insertdatetime';
+import 'tinymce/plugins/lists';
+import 'tinymce/plugins/link';
+import 'tinymce/plugins/media';
+import 'tinymce/plugins/paste';
+import 'tinymce/plugins/print';
+import 'tinymce/plugins/searchreplace';
+import 'tinymce/plugins/table';
+import 'tinymce/plugins/textcolor';
+import 'tinymce/plugins/visualblocks';
+import 'tinymce/plugins/wordcount';
 
 declare var manywho: any;
-
-// lazy loaded
-declare var tinymce: any;
 
 interface IContentState {
     isImageUploadOpen: boolean;
 }
 
 class Content extends React.Component<IComponentProps, IContentState> {
-
-    static isLoadingTinyMce: boolean = false;
-    static loadTinyMce(callback) {
-        Content.isLoadingTinyMce = true;
-
-        const script = document.createElement('script');
-        script.src = manywho.settings.global('richtext.url');
-
-        script.onload = () => {
-            Content.isLoadingTinyMce = false;
-            callback.apply();
-        };
-
-        window.document.body.appendChild(script);
-    }
 
     constructor(props) {
         super(props);
@@ -84,6 +92,7 @@ class Content extends React.Component<IComponentProps, IContentState> {
             relative_urls: false,
             remove_script_host: false,
             importcss_append: true,
+            skin: false,
 
             setup: (editor) => {
                 this.editor = editor;
@@ -118,23 +127,7 @@ class Content extends React.Component<IComponentProps, IContentState> {
     }
 
     componentDidMount() {
-        if (!(window as any).tinymce) {
-            if (!Content.isLoadingTinyMce) {
-                Content.loadTinyMce(() => this.initializeEditor());
-            } else {
-                const loaderInterval = setInterval(
-                    () => {
-                        if ((window as any).tinymce) {
-                            this.initializeEditor();
-                            clearInterval(loaderInterval);
-                        }
-                    },
-                    50,
-                );
-            }
-        } else {
-            this.initializeEditor();
-        }
+        this.initializeEditor();
     }
 
     componentWillUnmount() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,15 +293,6 @@
                 "@babel/types": "^7.4.4"
             }
         },
-        "@babel/helper-member-expression-to-functions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.0.0"
-            }
-        },
         "@babel/helper-module-imports": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
@@ -3805,8 +3796,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -11369,17 +11359,10 @@
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
-                "lodash": {
-                    "version": "4.17.14",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-                    "dev": true
-                },
                 "ansi-styles": {
                     "version": "3.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
                     "requires": {
                         "color-convert": "^1.9.0"
                     }
@@ -11388,7 +11371,6 @@
                     "version": "1.9.3",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
                     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
                     "requires": {
                         "color-name": "1.1.3"
                     }
@@ -11411,11 +11393,16 @@
                     "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
                     "dev": true
                 },
+                "lodash": {
+                    "version": "4.17.14",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+                    "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+                    "dev": true
+                },
                 "punycode": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-                    "dev": true
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
                 },
                 "string-width": {
                     "version": "3.1.0",
@@ -11792,6 +11779,11 @@
             "requires": {
                 "setimmediate": "^1.0.4"
             }
+        },
+        "tinymce": {
+            "version": "4.8.5",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.8.5.tgz",
+            "integrity": "sha512-1V6+PxP5Kp8H/Kuf+EOe6vyrtj1Dlj98q33DgiKGoGPTmbcQaVZWiT+lhqj8ICXKVLV3YxAieOJyJXai4SLHQg=="
         },
         "tmp": {
             "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "ramda": "0.26.1",
         "react": "16.8.6",
         "react-dom": "16.8.6",
-        "react-selectize": "3.0.1"
+        "react-selectize": "3.0.1",
+        "tinymce": "^4.8.5"
     }
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -48,7 +48,7 @@ const mapPublicPath = (assets, publicPaths) => {
 
 module.exports.config = {
     entry: {
-        'js/flow-ui-bootstrap': './js/index.js',        
+        'js/flow-ui-bootstrap': './js/index.js',
     },
     resolve: {
         extensions: ['.tsx', '.ts', '.js']
@@ -100,10 +100,15 @@ module.exports.plugins = [
     new CleanWebpackPlugin(pathsToClean),
     new MiniCssExtractPlugin({
         filename: '[name].css',
-    }),    
+    }),
 ];
 
 module.exports.rules = [
+    {
+        test: /\.css$/,
+        include: /node_modules\/tinymce\//,
+        use: ['style-loader', 'css-loader'],
+    },
     {
         test: /\.tsx?$/,
         use: 'babel-loader',
@@ -111,17 +116,17 @@ module.exports.rules = [
     },
     {
         test: /\.(woff|woff2|eot|ttf|svg|otf)$/,
-        use: 'file-loader?name=[path][name].[ext]'
+        use: 'file-loader?name=[name].[ext]&outputPath=css/fonts',
     },
     {
         test: /\.(png|svg|jpg|gif)$/,
-        use: 'file-loader?name=[path][name].[ext]'
+        use: 'file-loader?name=[name].[ext]&outputPath=img'
     },
     {
         test: /themes.*\.less$/,
         use: [
-            MiniCssExtractPlugin.loader, 
-            'css-loader', 
+            MiniCssExtractPlugin.loader,
+            'css-loader',
             'less-loader',
         ],
     },
@@ -207,7 +212,7 @@ module.exports.run = (config, defaultDirectory) => (env = {}) => {
             }
 
             config.devtool = sourcemaps ? 'source-map' : 'none';
-            
+
             config.output.publicPath = publicPath;
 
             config.output.path = path.resolve(__dirname, outputPath);


### PR DESCRIPTION
This adds TinyMCE into the bundle output from Webpack, and seems to handle the skin and theme files in the bundle too.

I'm not sure if my changes to the Webpack configuration break anything, but from a quick glance around the tooling it looks like fonts and images were the same as before the change (i.e. map element icons were missing before this change already 😉 ).