### PR TITLE
FLOW-405: Fixed outcomes not wrapping on smaller screens

### DIFF
--- a/css/outcomes.less
+++ b/css/outcomes.less
@@ -1,8 +1,4 @@
 .mw-bs {
-    .mw-outcomes > .row:not(.block) {
-        display: flex;
-    }
-
     .justify-right {
         justify-content: flex-end;
     }


### PR DESCRIPTION
This CSS rule seems to not be usedful for anything with outcomes, except that it breaks wrapping of long outcomes on smaller screens. I tested with the QA flow for the original ticket where this rule was added (CORE-2810) and the flow still works as expected.