### PR TITLE
FLOW-608: Prevent sorting null data

### DIFF
--- a/__tests__/items-container.test.tsx
+++ b/__tests__/items-container.test.tsx
@@ -959,4 +959,11 @@ describe('ItemsContainer component behaviour', () => {
         objectData.sort(componentWrapper.instance().compare('object', true));
         expect(objectData).toEqual(sortingTestData);
     });
+
+    test('Verify sort method not called on null objectData', () => {
+        globalAny.window.manywho.utils.isNullOrWhitespace = () => true;
+        componentWrapper = manyWhoMount({ objectData: null });
+        expect(() => componentWrapper.setState({ search: null, sortedBy: 'test', sortedIsAscending: true })).not.toThrow();
+    });
+
 });

--- a/js/components/items-container.tsx
+++ b/js/components/items-container.tsx
@@ -354,7 +354,7 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
             }
 
             // Sort the filtered list before slicing
-            if (this.state.sortedBy) {
+            if (this.state.sortedBy && Array.isArray(objectData)) {
                 objectData.sort(this.compare(this.state.sortedBy, this.state.sortedIsAscending));
             }
 


### PR DESCRIPTION
Trivial - I hope.

Just added a check that objectData is iterable.

