### PR TITLE
FLOW-632: Ensure dropdown selection remains selected if pagination is enabled

### DIFF
--- a/js/components/select.tsx
+++ b/js/components/select.tsx
@@ -21,6 +21,8 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
 
     debouncedOnSearch = null;
 
+    debouncedOnScroll = null;
+
     constructor(props) {
         super(props);
         this.state = { options: [], search: '', isOpen: false };
@@ -241,8 +243,8 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
      *
      * Match on `externalId` or the `internalId` because when offline there is no externalId
      *
-     * @param Array existingOptions current list of options
-     * @param Array newOptions extra options to append or replace. These new options may be the next page or the selected item(s).
+     * @param {Array} existingOptions current list of options
+     * @param {Array} newOptions extra options to append or replace. These new options may be the next page or the selected item(s).
      */
     addOptions(existingOptions, newOptions) {
 

--- a/js/components/select.tsx
+++ b/js/components/select.tsx
@@ -54,12 +54,13 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
         const hasRequest = model.objectDataRequest !== null || model.fileDataRequest !== null;
 
         if ((doneLoading || !hasRequest) && nextProps.objectData && !nextProps.isDesignTime) {
-            let options = this.getOptions(nextProps.objectData);
+            let options = [];
 
             if (
                 nextProps.page > 1 &&
                 this.state.options.length < nextProps.limit * nextProps.page
             ) {
+                options = this.state.options.concat(this.getOptions(nextProps.objectData));
                 this.setState({ isOpen: true });
 
                 const index = this.state.options.length + 1;
@@ -71,6 +72,8 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
                     const scrollTarget = dropdown.children.item(index) as HTMLElement;
                     dropdown.scrollTop = scrollTarget.offsetTop;
                 });
+            } else {
+                options = this.getOptions(nextProps.objectData);
             }
 
             if (state && state.objectData) {
@@ -255,6 +258,7 @@ class Select extends React.Component<IItemsComponentProps, IDropDownState> {
             this.props.hasMoreResults
         ) {
             this.props.onNext();
+            this.setState({ isOpen: true });
         }
     }
 


### PR DESCRIPTION
The issue was essentially that with pagination enabled we only get small chunks of all the available options, and if a user selects an option from the list, when the dropdown control is refreshed the selected item may no longer be within the chunk/page of data returned.

The dropdown can not display a selection if that selection is not in the list of options.

The fix is to merge the selected item into the currently displayed 'page' of options so the dropdown can display the selected item because it's now a matching item in the list of options.