### PR TITLE
FLOW-845: Ensure state accurately reflects users input when clearing …

### DIFF
--- a/js/components/input-datetime.tsx
+++ b/js/components/input-datetime.tsx
@@ -51,15 +51,15 @@ class InputDateTime extends React.Component<IInputProps, null> {
         ) {
             return date.local().format();
         }
-            
+
         return date.utc().format();
     }
 
     onChange = (e) => {
         if (!this.props.isDesignTime) {
-            if (!e.date)
-                this.props.onChange(null);
-            else if (e.date.isValid())
+            if (!e.date) {
+                this.props.onChange('');
+            } else if (e.date.isValid()) {
 
                 // This check is happening as, if just the timepicker is being used
                 // the expected behaviour is that the page components default value
@@ -67,7 +67,7 @@ class InputDateTime extends React.Component<IInputProps, null> {
                 if (this.isTimeOnly &&
                     this.props.value !== null &&
                     !(e.date.isSame(this.props.value))) {
-    
+
                     const defaultDate: any = this.props.value;
                     const defaultMomentDate = moment(
                         defaultDate,
@@ -83,8 +83,9 @@ class InputDateTime extends React.Component<IInputProps, null> {
                 } else {
                     this.props.onChange(this.format(e.date));
                 }
-            else
+            } else {
                 this.props.onChange(e.target.value);
+            }
         }
     }
 
@@ -93,16 +94,16 @@ class InputDateTime extends React.Component<IInputProps, null> {
         const datepickerInstance = $(datepickerElement).data('DateTimePicker');
 
         let date = moment(
-            newDate, 
+            newDate,
             [
-                'MM/DD/YYYY hh:mm:ss A ZZ', 'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ', 
+                'MM/DD/YYYY hh:mm:ss A ZZ', 'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ',
                 moment.ISO_8601,
             ],
         );
         let UTCdate = moment.utc(
             newDate,
             [
-                'MM/DD/YYYY hh:mm:ss A ZZ', 'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ', 
+                'MM/DD/YYYY hh:mm:ss A ZZ', 'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ',
                 moment.ISO_8601,
             ],
         );
@@ -136,8 +137,8 @@ class InputDateTime extends React.Component<IInputProps, null> {
 
         if (model.attributes) {
             if (model.attributes.useCurrent !== undefined)
-                useCurrent = manywho.utils.isEqual(model.attributes.useCurrent, 'true', true) ? 
-                    true : 
+                useCurrent = manywho.utils.isEqual(model.attributes.useCurrent, 'true', true) ?
+                    true :
                     false;
 
             if (model.attributes.dateTimeFormat)
@@ -145,13 +146,13 @@ class InputDateTime extends React.Component<IInputProps, null> {
         }
 
         if (customFormat) {
-            this.isDateOnly = 
-                customFormat.toLowerCase().indexOf('h') === -1 && 
+            this.isDateOnly =
+                customFormat.toLowerCase().indexOf('h') === -1 &&
                 customFormat.indexOf('m') === -1 && // minute is always lower case, M is always month
                 customFormat.toLowerCase().indexOf('s') === -1;
 
-            if (!this.isDateOnly) { 
-                this.isTimeOnly = 
+            if (!this.isDateOnly) {
+                this.isTimeOnly =
                     (customFormat.toLowerCase().indexOf('h') > -1 &&
                     customFormat.indexOf('m') > -1 ||
                     customFormat.toLowerCase().indexOf('s') > -1)
@@ -168,8 +169,8 @@ class InputDateTime extends React.Component<IInputProps, null> {
             useCurrent,
             locale: model.attributes.dateTimeLocale || 'en-us',
             focusOnShow: false,
-            format: customFormat || 
-                manywho.formatting.toMomentFormat(model.contentFormat) || 
+            format: customFormat ||
+                manywho.formatting.toMomentFormat(model.contentFormat) ||
                 'MM/DD/YYYY',
             timeZone: 'UTC',
         })
@@ -177,9 +178,9 @@ class InputDateTime extends React.Component<IInputProps, null> {
 
         if (!this.props.isDesignTime) {
             if (this.isEmptyDate(this.props.value)) {
-                
+
                 manywho.state.setComponent(
-                    this.props.id, { contentValue: null }, this.props.flowKey, true,
+                    this.props.id, { contentValue: '' }, this.props.flowKey, true,
                 );
 
             } else {


### PR DESCRIPTION
…a date otherwise the next re-render uses a stale state value.

Essentially the issue is due to this line in input.tsx,

https://github.com/manywho/ui-bootstrap/blob/develop/js/components/input.tsx#L118

In the datetime component, when a user cleared the input, state.contentValue was set to null. The line above then uses model.contentValue - which is stale.

I didn't want to change this test in input.tsx because input is the parent of many components and really the fix should be isolated to the datetime component, rather than special case code in a generic component.

The fix is to therefore behave like the other child components and pass a '' state value when clearing the datetime input, so that the test above uses the correct state or model value.

A possible behaviour change might be that when saving a changed blank date the value stored may be '' rather than null if you never enter a date.