### PR TITLE
FLOW-1601 removing click evented generated after an onblur event

### DIFF
--- a/js/components/input.tsx
+++ b/js/components/input.tsx
@@ -76,19 +76,6 @@ class Input extends React.Component<IComponentProps, null> {
     }
 
     onBlur(e) {
-        let callback = null;
-        const relatedElement = e.relatedTarget;
-
-        if (
-            relatedElement &&
-            (
-                relatedElement.classList.contains('outcome') ||
-                relatedElement.classList.contains('control-label')
-            )
-        ) {
-            callback = () => relatedElement.click();
-        }
-
         manywho.component.handleEvent(
             this,
             manywho.model.getComponent(
@@ -96,7 +83,7 @@ class Input extends React.Component<IComponentProps, null> {
                 this.props.flowKey,
             ),
             this.props.flowKey,
-            callback,
+            null,
         );
     }
 


### PR DESCRIPTION
When there was an input field and after and outcome (button), and the user press tab moving the focus from the input to the button, the code behaves as the user has clicked the button.