### PR TITLE
FLOw-1729: Removed unnecessary duplicate setComponent call

### DIFF
--- a/__tests__/input.test.tsx
+++ b/__tests__/input.test.tsx
@@ -180,7 +180,6 @@ describe('Input component behaviour', () => {
         inputWrapper.find('input').simulate('change', { target: { value: 'text' } });
         expect(onchangeSpy).toHaveBeenCalled();
         expect(globalAny.window.manywho.state.getComponent).toHaveBeenCalled();
-        expect(globalAny.window.manywho.validation.validate).toHaveBeenCalled();
         expect(globalAny.window.manywho.state.setComponent).toHaveBeenCalledTimes(2);
     });
 

--- a/js/components/input.tsx
+++ b/js/components/input.tsx
@@ -60,14 +60,6 @@ class Input extends React.Component<IComponentProps, null> {
             );
         }
 
-        const state = manywho.state.getComponent(this.props.id, this.props.flowKey) || {};
-        manywho.state.setComponent(
-            this.props.id,
-            manywho.validation.validate(model, state, this.props.flowKey),
-            this.props.flowKey,
-            true,
-        );
-
         if (model.contentType.toUpperCase() === manywho.component.contentTypes.boolean) {
             this.onBlur(e);
         }


### PR DESCRIPTION
This removes a second call to `manywho.state.setComponent`, which looks like it was only there to manually handle validation, but validation is already handled inside the first `setComponent` call above.