### PR TITLE
FLOW-2004 - Collapse historical navigation when outcomes are clicked

### DIFF
--- a/js/components/historical-navigation.tsx
+++ b/js/components/historical-navigation.tsx
@@ -24,6 +24,21 @@ const HistoricalNavigation:React.FC<IComponentProps> = ({ flowKey }) => {
         navigateToPath(flowKey, entry.path);
     };
 
+    // When any outcome is clicked we want to collapse the history nav
+    const handleClick = ({ target }) => {           
+        if (target.classList.contains('outcome') || target.closest('.outcome')) {
+            setExpanded(false);
+        }
+    };
+    
+    React.useEffect(() => {
+        document.addEventListener('click', handleClick);
+
+        return () => {
+            document.removeEventListener('click', handleClick);
+        };
+    }, [handleClick]);
+
     if (navigation && navigation.entries && navigation.entries.length > 0) {
 
         return (

--- a/js/components/historical-navigation.tsx
+++ b/js/components/historical-navigation.tsx
@@ -24,20 +24,10 @@ const HistoricalNavigation:React.FC<IComponentProps> = ({ flowKey }) => {
         navigateToPath(flowKey, entry.path);
     };
 
-    // When any outcome is clicked we want to collapse the history nav
-    const handleClick = ({ target }) => {           
-        if (target.classList.contains('outcome') || target.closest('.outcome')) {
-            setExpanded(false);
-        }
-    };
-    
+    // When history nav entries change we want to collapse it
     React.useEffect(() => {
-        document.addEventListener('click', handleClick);
-
-        return () => {
-            document.removeEventListener('click', handleClick);
-        };
-    }, [handleClick]);
+        setExpanded(false);
+    }, [navigation ? navigation.entries : null]);
 
     if (navigation && navigation.entries && navigation.entries.length > 0) {
 

--- a/js/lib/010-pollyfills.js
+++ b/js/lib/010-pollyfills.js
@@ -69,3 +69,21 @@ if (!Array.prototype.findIndex) {
     writable: true
   });
 }
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector || 
+                              Element.prototype.webkitMatchesSelector;
+}
+
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var el = this;
+
+    do {
+      if (Element.prototype.matches.call(el, s)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}

--- a/js/lib/010-pollyfills.js
+++ b/js/lib/010-pollyfills.js
@@ -69,21 +69,3 @@ if (!Array.prototype.findIndex) {
     writable: true
   });
 }
-
-// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
-if (!Element.prototype.matches) {
-  Element.prototype.matches = Element.prototype.msMatchesSelector || 
-                              Element.prototype.webkitMatchesSelector;
-}
-
-if (!Element.prototype.closest) {
-  Element.prototype.closest = function(s) {
-    var el = this;
-
-    do {
-      if (Element.prototype.matches.call(el, s)) return el;
-      el = el.parentElement || el.parentNode;
-    } while (el !== null && el.nodeType === 1);
-    return null;
-  };
-}


### PR DESCRIPTION
First approach was adding a collapsed property into ui-core state. This led to making changes in many other places and adding another call Engine.render. It didn't seem ideal.
To keep the functionality contained within the historical-navigation component I have added a document event listener which will execute when an outcome is clicked. The listener will update the local component state to collapse the navigation items.

Edit: Changed the approach to collapsing the historical nav items whenever the entries array changes.