### PR TITLE
FLOW-1910: Re-enable outcome justification with additional wrapping

### DIFF
--- a/css/outcomes.less
+++ b/css/outcomes.less
@@ -1,4 +1,9 @@
 .mw-bs {
+    .mw-outcomes > .row:not(.block) {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
     .justify-right {
         justify-content: flex-end;
     }


### PR DESCRIPTION
To fix the `display: flex` is added again with the addition of `flex-wrap: wrap` so the justification will work again and the outcomes/buttons will wrap onto new lines when they run out of horizontal space.