### PR TITLE
FLOW-2101 - stopping getClasses from being called with no id

### DIFF
--- a/js/components/file-upload.tsx
+++ b/js/components/file-upload.tsx
@@ -80,14 +80,18 @@ const FileUploadWrapper: React.SFC<IFileUploadProps> = (props) => {
     const fileUploadComponent = (
         <FileUpload
             id={props.id}
-            className={(
-                manywho.styling.getClasses(
-                    props.parentId,
-                    props.id,
-                    'file_upload',
-                    props.flowKey,
-                )
-            ).join(' ')}
+            className={
+                props.id ?
+                    (
+                        manywho.styling.getClasses(
+                            props.parentId,
+                            props.id,
+                            'file_upload',
+                            props.flowKey,
+                        )
+                    ).join(' ') :
+                    null
+            }
             multiple={manywho.utils.isNullOrUndefined(props.multiple) ? model.isMultiSelect : props.multiple}
             upload={(files, progress) => Promise.resolve(props.upload(
                 props.flowKey,


### PR DESCRIPTION
getClasses in ui-core throws an error if it is called without an id.
So this fix makes sure we don't ask for classes, if we know that we don't have an id, so we know none will be found even if it didn't throw an error.