### PR TITLE
Feature/FLOW-2267 Comboboxes reverse the order of items when there is a selected value

### DIFF
--- a/__tests__/select.test.tsx
+++ b/__tests__/select.test.tsx
@@ -317,7 +317,7 @@ describe('Select input component behaviour', () => {
                 properties: [
                     {
                         typeElementPropertyId,
-                        contentValue: str(10),
+                        contentValue: 'Page 1 Value',
                         contentFormat: '',
                         contentType: 'ContentString',
                         developerName: 'value',
@@ -336,7 +336,7 @@ describe('Select input component behaviour', () => {
                 properties: [
                     {
                         typeElementPropertyId,
-                        contentValue: str(10),
+                        contentValue: 'Page 2 Value',
                         contentFormat: '',
                         contentType: 'ContentString',
                         developerName: 'value',
@@ -354,6 +354,7 @@ describe('Select input component behaviour', () => {
 
         selectWrapper.setProps({ isLoading: false, objectData: pageTwoObjData, page: 2 });
         expect(selectWrapper.state().options.length).toEqual(2);
+        expect(selectWrapper.state().options.map(option => option.label)).toEqual(['Page 1 Value','Page 2 Value']);
         expect(selectWrapper.state().isOpen).toBeTruthy();
     });
 
@@ -393,6 +394,52 @@ describe('Select input component behaviour', () => {
         const selectWrapperInstance = selectWrapper.instance();
         selectWrapperInstance.isScrollLimit(event);
         expect(props.onNext).toHaveBeenCalled();
+    });
+
+    test('when addOptions is called with items selected, selected items are reversed and prepended', () => {
+        const typeElementPropertyId = str(10);
+        const developerName = str();
+        
+        const contentValues = [];
+        const existingOptions = [];
+        // add 3 items to the combo box list: A,B,C,D
+        for (let i = 0; i < 4; i++) {
+            contentValues.push(str());
+            existingOptions.push({ 
+                value: {
+                    developerName,
+                    externalId: str(),
+                    internalId: str(),
+                    isSelected: false,
+                    properties: [
+                        {
+                            typeElementPropertyId,
+                            contentValue: contentValues[contentValues.length - 1],
+                            contentFormat: '',
+                            contentType: 'ContentString',
+                            developerName: 'value',
+                            externalId: str(10),
+                        },
+                    ],
+                },
+                label: contentValues[contentValues.length - 1]
+            });
+        }
+        // add 2 of those 4 items to the selected list: B,C
+        const selectedOptions = [existingOptions[1], existingOptions[2]];
+        selectedOptions.forEach(selectedOption => {
+            selectedOption.value.isSelected = true
+        });
+        
+        selectWrapper = manyWhoMount();
+        const selectWrapperInstance = selectWrapper.instance();
+        // call addOptions with existing list A,B,C,D. and a selected list B,C
+        const resultContentValues = selectWrapperInstance
+            .addOptions(existingOptions, selectedOptions, false)
+            .map(option => option.label);
+        
+        // expect C,B,A,D as B,C is reversed and prepended to A,B,C,D. then duplicates removed
+        expect(resultContentValues).toEqual([contentValues[2],contentValues[1],contentValues[0],contentValues[3]]);
     });
     
 });


### PR DESCRIPTION
**issue**: order of options in the combo box was reversing before you selected an item
**reason**: addOptions was reversing the list of options every time it was called
it gets called only once on line 91 if you have nothing selected - therefore the list is reversed
but it gets called a second time on line 96 if you have something selected - therefore the list was no longer reversed
**why it only affected data from a service**: if you don't have something selected but get it from a List rather than a service state.objectData is an empty list rather than null so the condition on line 94 passes as if you had something selected

my changes mean that only the selected items are reversed (so the most recently selected item is at the top)
my changes also fix an issue where the next page of items was being prepended and reversed as if they were the selected items, now there is a flag to append the next page (append = true) or prepend the selected items in reverse order (append = false)