### PR TITLE
FLOW-2018: Use dompurify to sanitize presentation content output

### DIFF
--- a/__tests__/presentation.test.tsx
+++ b/__tests__/presentation.test.tsx
@@ -42,21 +42,23 @@ describe('Presentation component behaviour', () => {
     test('DOMPurify removes dangerous scripting', () => {
 
         globalAny.window.manywho.utils.isNullOrUndefined = () => false;
-        globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)" />' });
+        globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)">' });
         globalAny.window.manywho.settings.global = () => false;
+        console.error = jest.fn();
 
         componentWrapper = manyWhoMount({ id: 'test', flowKey: 'a' });
-        expect(componentWrapper.instance().forTestingOnly()).toEqual('<img src="x" />');
+        expect(componentWrapper.instance().forTestingOnly()).toEqual('<img src="x">');
+        expect(console.error).toHaveBeenCalled();
     });
 
     test('DOMPurify leaves dangerous scripting with option enabled', () => {
 
         globalAny.window.manywho.utils.isNullOrUndefined = () => false;
-        globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)" />' });
+        globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)">' });
         globalAny.window.manywho.settings.global = () => true; // Don't purify
 
         componentWrapper = manyWhoMount({ id: 'test', flowKey: 'a' });
-        expect(componentWrapper.instance().forTestingOnly()).toEqual('<img src="x" onerror="alert(1)" />');
+        expect(componentWrapper.instance().forTestingOnly()).toEqual('<img src="x" onerror="alert(1)">');
     });
 
 });

--- a/__tests__/presentation.test.tsx
+++ b/__tests__/presentation.test.tsx
@@ -43,7 +43,7 @@ describe('Presentation component behaviour', () => {
 
         globalAny.window.manywho.utils.isNullOrUndefined = () => false;
         globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)">' });
-        globalAny.window.manywho.settings.global = () => false;
+        globalAny.window.manywho.settings.global = () => true; // Fake Player setting, disableScripting == true
         console.error = jest.fn();
 
         componentWrapper = manyWhoMount({ id: 'test', flowKey: 'a' });
@@ -51,11 +51,11 @@ describe('Presentation component behaviour', () => {
         expect(console.error).toHaveBeenCalled();
     });
 
-    test('DOMPurify leaves dangerous scripting with option enabled', () => {
+    test('DOMPurify leaves dangerous scripting with option disabled', () => {
 
         globalAny.window.manywho.utils.isNullOrUndefined = () => false;
         globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)">' });
-        globalAny.window.manywho.settings.global = () => true; // Don't purify
+        globalAny.window.manywho.settings.global = () => false; // Fake Player setting, disableScripting == false
 
         componentWrapper = manyWhoMount({ id: 'test', flowKey: 'a' });
         expect(componentWrapper.instance().forTestingOnly()).toEqual('<img src="x" onerror="alert(1)">');

--- a/__tests__/presentation.test.tsx
+++ b/__tests__/presentation.test.tsx
@@ -11,7 +11,6 @@ describe('Presentation component behaviour', () => {
 
     function manyWhoMount(props) {
 
-        globalAny.window.manywho.utils.isNullOrUndefined = () => false;
         return mount(<Presentation {...props} />);
     }
 
@@ -32,6 +31,7 @@ describe('Presentation component behaviour', () => {
 
     test('Simple render', () => {
 
+        globalAny.window.manywho.utils.isNullOrUndefined = () => false;
         globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: 'test content' });
         globalAny.window.manywho.settings.global = () => false;
 
@@ -41,6 +41,7 @@ describe('Presentation component behaviour', () => {
 
     test('DOMPurify removes dangerous scripting', () => {
 
+        globalAny.window.manywho.utils.isNullOrUndefined = () => false;
         globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)" />' });
         globalAny.window.manywho.settings.global = () => false;
 
@@ -50,6 +51,7 @@ describe('Presentation component behaviour', () => {
 
     test('DOMPurify leaves dangerous scripting with option enabled', () => {
 
+        globalAny.window.manywho.utils.isNullOrUndefined = () => false;
         globalAny.window.manywho.model.getComponent = () => ({ visible: true, content: '<img src="x" onerror="alert(1)" />' });
         globalAny.window.manywho.settings.global = () => true; // Don't purify
 

--- a/js/components/presentation.tsx
+++ b/js/components/presentation.tsx
@@ -4,6 +4,7 @@ import registeredComponents from '../constants/registeredComponents';
 import IComponentProps from '../interfaces/IComponentProps';
 import { getOutcome } from './outcome';
 import { renderOutcomesInOrder } from './utils/CoreUtils';
+import DOMPurify from 'dompurify';
 
 declare var manywho: any;
 
@@ -56,7 +57,7 @@ class Presentation extends React.Component<IComponentProps, null> {
         const presentationField = (
             <div>
                 <label>{model.label}</label>
-                <div ref="content" dangerouslySetInnerHTML={{ __html: html }} />
+                <div ref="content" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />
                 <span className="help-block">
                     {model.validationMessage || state.validationMessage}
                 </span>

--- a/js/components/presentation.tsx
+++ b/js/components/presentation.tsx
@@ -4,7 +4,11 @@ import registeredComponents from '../constants/registeredComponents';
 import IComponentProps from '../interfaces/IComponentProps';
 import { getOutcome } from './outcome';
 import { renderOutcomesInOrder } from './utils/CoreUtils';
-import DOMPurify from 'dompurify';
+
+// Can't use import otherwise the Jest tests fail to find DOMPurify
+const createDOMPurify = require('dompurify');
+
+const DOMPurify = createDOMPurify(window);
 
 declare var manywho: any;
 

--- a/js/components/presentation.tsx
+++ b/js/components/presentation.tsx
@@ -68,10 +68,11 @@ class Presentation extends React.Component<IComponentProps, null> {
                 .replace(/&gt;/g, '>')
                 .replace(/&amp;/g, '&');
 
-            // By default, strip any dangerous Javascript with an optional config to allow/disallow certain
-            // tags or attributes.
-            if (!manywho.settings.global('allow-scripting', this.props.flowKey, false)) {
-                this.html = DOMPurify.sanitize(this.html, manywho.settings.global('allow-scripting-configuration', this.props.flowKey, null));
+            // By default, do not strip any dangerous Javascript, to avoid breaking existing Flows without this Player setting
+            // The default player, for new customers/flows, will have this setting enabled by default.
+            // Allow an optional DOMPurify config to allow/disallow certain tags or attributes.
+            if (manywho.settings.global('disableScripting', this.props.flowKey, false)) {
+                this.html = DOMPurify.sanitize(this.html, manywho.settings.global('disableScriptingConfiguration', this.props.flowKey, null));
                 if (DOMPurify.removed && DOMPurify.removed.length > 0) {
                     // Notify someone so we can identify Flows that have been affected, which
                     // may not be desirable for some customers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1277,9 +1277,9 @@
             }
         },
         "@boomi/react-file-upload": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@boomi/react-file-upload/-/react-file-upload-0.3.0.tgz",
-            "integrity": "sha512-rFlFFd+NfxDj9JcUz/kcVXdipxTguyyPeT7dea9bdEm/gYRWPJUS5APELDzD0lskrpbSSYrZ2ErgACV1kaUUIA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@boomi/react-file-upload/-/react-file-upload-0.4.0.tgz",
+            "integrity": "sha512-/eq9/20bpIwRGHHJQfdMj66xiprZ9LNntIN9BChCAGjeofOQmGqJLabC7TjE62ELcfZrM2AfcNYNqkvZ+PQlPg==",
             "requires": {
                 "react-dropzone": "^4.2.10"
             }
@@ -4396,6 +4396,11 @@
                 "domelementtype": "1"
             }
         },
+        "dompurify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.1.1.tgz",
+            "integrity": "sha512-NijiNVkS/OL8mdQL1hUbCD6uty/cgFpmNiuFxrmJ5YPH2cXrPKIewoixoji56rbZ6XBPmtM8GA8/sf9unlSuwg=="
+        },
         "domutils": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
@@ -5840,8 +5845,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -6256,8 +6260,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -6313,7 +6316,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -6357,14 +6359,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "babel-loader": "8.0.5",
         "core-js": "^3.6.4",
         "create-react-class": "15.6.3",
+        "dompurify": "^2.1.1",
         "extract-text-webpack-plugin": "4.0.0-beta.0",
         "jquery": "3.4.1",
         "lint": "1.1.2",


### PR DESCRIPTION
Ensure any user entered input has dangerous Javascript removed before rendering in the presentation components.

For example,

`<img src="x" onerror=alert(1) />
`
converts to,

`<img src="x">
`
See https://github.com/cure53/DOMPurify for details.