### PR TITLE
FLOW-1904 - Using responseJSON for errors if they are strings to remove unnecessary quotes

### DIFF
--- a/__tests__/login.test.tsx
+++ b/__tests__/login.test.tsx
@@ -30,8 +30,13 @@ describe('Login component behaviour', () => {
 
     const mockSuccess = 'mockSuccess';
 
-    const mockFailWithObjectJSON = {
+    const mockFailWithObjectNoMessageJSON = {
         responseJSON: { json: true },
+        responseText: 'responseTextError',
+    }
+
+    const mockFailWithObjectMessageJSON = {
+        responseJSON: { message: 'responseJSONMessage' },
         responseText: 'responseTextError',
     }
 
@@ -44,8 +49,12 @@ describe('Login component behaviour', () => {
         then: (thenFunction) => { thenFunction(mockSuccess); return ({ fail: () => {} }) },
     });
 
-    const mockFailWithObjectJSONAjax = () => ({
-        then: () => ({ fail: (failFunction) => failFunction(mockFailWithObjectJSON) }),
+    const mockFailWithObjectNoMessageJSONAjax = () => ({
+        then: () => ({ fail: (failFunction) => failFunction(mockFailWithObjectNoMessageJSON) }),
+    });
+
+    const mockFailWithObjectMessageJSONAjax = () => ({
+        then: () => ({ fail: (failFunction) => failFunction(mockFailWithObjectMessageJSON) }),
     });
 
     const mockFailWithStringJSONAjax = () => ({
@@ -204,8 +213,8 @@ describe('Login component behaviour', () => {
         expect(componentWrapper.state('faults')).toBe(mockFailWithStringJSON.responseJSON);
     });
 
-    test('When OnSubmit login fails, and the error responseJSON is not a string, the responseText is displayed', () => {
-        globalAny.window.manywho.ajax = { login: jest.fn(mockFailWithObjectJSONAjax) };
+    test('When OnSubmit login fails, and the error responseJSON is not a string, but responseJSON.message is, then responseJSON.message is displayed', () => {
+        globalAny.window.manywho.ajax = { login: jest.fn(mockFailWithObjectMessageJSONAjax) };
         
         componentWrapper = manyWhoMount();
         
@@ -231,7 +240,37 @@ describe('Login component behaviour', () => {
 
         expect(componentWrapper.state('loading')).toBe(null);
         expect(componentWrapper.state('password')).toBe('');
-        expect(componentWrapper.state('faults')).toBe(mockFailWithObjectJSON.responseText);
+        expect(componentWrapper.state('faults')).toBe(mockFailWithObjectMessageJSON.responseJSON.message);
+    });
+
+    test('When OnSubmit login fails, and the error responseJSON is not a string, and responseJSON.message also isn\'t, then responseText is displayed', () => {
+        globalAny.window.manywho.ajax = { login: jest.fn(mockFailWithObjectNoMessageJSONAjax) };
+        
+        componentWrapper = manyWhoMount();
+        
+        const username = 'test@example.com';
+        const password = 'test';
+        
+        componentWrapper.instance().setState({
+            username,
+            password
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).toHaveBeenCalledWith(
+            props.loginUrl,
+            username,
+            password,
+            null,
+            null,
+            props.stateId,
+            tenantId,
+        );
+
+        expect(componentWrapper.state('loading')).toBe(null);
+        expect(componentWrapper.state('password')).toBe('');
+        expect(componentWrapper.state('faults')).toBe(mockFailWithObjectNoMessageJSON.responseText);
     });
 
 });

--- a/__tests__/login.test.tsx
+++ b/__tests__/login.test.tsx
@@ -1,5 +1,3 @@
-import { str } from '../test-utils';
-
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
@@ -11,26 +9,70 @@ describe('Login component behaviour', () => {
 
     const globalAny:any = global;
 
-    function manyWhoMount() {
+    const props = {
+        callback: {
+            execute: { apply: jest.fn() },
+            context: 'testContext',
+            args: [{
+                execute: null,
+                context: null,
+                args: null,
+            }],
+        },
+        loginUrl: 'testLoginUrl',
+        stateId: 'testStateId',
+        username: 'testUsername',
+        directoryName: 'testDirectoryName',
+        flowKey: 'testFlowKey',
+    };
 
-        const props = {
-            callback: {
-                execute: () => {},
-                context: {},
-                args: {},
-            },
-            loginUrl: str(5),
-            stateId: str(5),
-            username: str(5),
-            directoryName: str(5),
-        };
+    const tenantId = 'testTenantId';
+
+    const mockSuccess = 'mockSuccess';
+
+    const mockFailWithObjectJSON = {
+        responseJSON: { json: true },
+        responseText: 'responseTextError',
+    }
+
+    const mockFailWithStringJSON = {
+        responseJSON: 'responseJSONError',
+        responseText: 'responseTextError',
+    }
+
+    const mockSuccessAjax = () => ({
+        then: (thenFunction) => { thenFunction(mockSuccess); return ({ fail: () => {} }) },
+    });
+
+    const mockFailWithObjectJSONAjax = () => ({
+        then: () => ({ fail: (failFunction) => failFunction(mockFailWithObjectJSON) }),
+    });
+
+    const mockFailWithStringJSONAjax = () => ({
+        then: () => ({ fail: (failFunction) => failFunction(mockFailWithStringJSON) }),
+    });
+
+    function manyWhoMount() {
 
         globalAny.window.manywho.model.getComponent = () => ({
             attributes: {},
         });
+        globalAny.window.manywho.authorization = { setAuthenticationToken: jest.fn() };
+        globalAny.window.manywho.state.setLogin = jest.fn();
+        globalAny.window.manywho.utils.extractTenantId = jest.fn(() => tenantId);
+        globalAny.window.manywho.utils.isNullOrWhitespace = (value: string): boolean => {
+            if (typeof value === 'undefined' || value === null) {
+                return true;
+            }
+            return value.replace(/\s/g, '').length < 1;
+        };
 
         return shallow(<Login {...props} />);
     }
+
+    beforeEach(() => {
+        globalAny.window.manywho.ajax = { login: jest.fn(mockSuccessAjax) };
+    });
 
     afterEach(() => {
         componentWrapper.unmount();
@@ -45,6 +87,151 @@ describe('Login component behaviour', () => {
         componentWrapper = manyWhoMount();
         expect(globalAny.window.manywho.component.register)
         .toHaveBeenCalledWith('mw-login', Login, ['mw_login']); 
+    });
+
+    test('When OnSubmit login is called without username or password, an error is shown', () => {
+        componentWrapper = manyWhoMount();
+        
+        const username = 'test@example.com';
+        const password = 'test';
+        
+        // First test without any data
+        componentWrapper.instance().setState({
+            username: null,
+            password: null
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).not.toBeCalled();
+        expect(componentWrapper.state('usernameError')).toBe('This field is required.');
+        expect(componentWrapper.state('passwordError')).toBe('This field is required.');
+
+        componentWrapper = manyWhoMount();
+
+        // Then test without username
+        componentWrapper.instance().setState({
+            username: null,
+            password
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).not.toBeCalled();
+        expect(componentWrapper.state('usernameError')).toBe('This field is required.');
+        expect(componentWrapper.state('passwordError')).toBe("");
+
+        componentWrapper = manyWhoMount();
+
+        // Then test without password
+        componentWrapper.instance().setState({
+            username,
+            password: null
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).not.toBeCalled();
+        expect(componentWrapper.state('usernameError')).toBe("");
+        expect(componentWrapper.state('passwordError')).toBe('This field is required.');
+    });
+
+    test('When OnSubmit login succeeds, manywho state, auth and callback is updated to auth details', () => {
+        componentWrapper = manyWhoMount();
+        
+        const username = 'test@example.com';
+        const password = 'test';
+        
+        componentWrapper.instance().setState({
+            username,
+            password
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).toHaveBeenCalledWith(
+            props.loginUrl,
+            username,
+            password,
+            null,
+            null,
+            props.stateId,
+            tenantId,
+        );
+
+        expect(manywho.state.setLogin).toHaveBeenCalledWith(
+            null,
+            props.flowKey
+        );
+        expect(manywho.authorization.setAuthenticationToken).toHaveBeenCalledWith(
+            mockSuccess,
+            props.flowKey
+        );
+        expect(props.callback.execute.apply).toHaveBeenCalledWith(
+            props.callback.context,
+            [props.callback].concat(props.callback.args)
+        );
+        expect(componentWrapper.state('faults')).toBe(null);
+    });
+
+    test('When OnSubmit login fails, and the error responseJSON is a string, the string is displayed', () => {
+        globalAny.window.manywho.ajax = { login: jest.fn(mockFailWithStringJSONAjax) };
+        
+        componentWrapper = manyWhoMount();
+        
+        const username = 'test@example.com';
+        const password = 'test';
+        
+        componentWrapper.instance().setState({
+            username,
+            password
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).toHaveBeenCalledWith(
+            props.loginUrl,
+            username,
+            password,
+            null,
+            null,
+            props.stateId,
+            tenantId,
+        );
+
+        expect(componentWrapper.state('loading')).toBe(null);
+        expect(componentWrapper.state('password')).toBe('');
+        expect(componentWrapper.state('faults')).toBe(mockFailWithStringJSON.responseJSON);
+    });
+
+    test('When OnSubmit login fails, and the error responseJSON is not a string, the responseText is displayed', () => {
+        globalAny.window.manywho.ajax = { login: jest.fn(mockFailWithObjectJSONAjax) };
+        
+        componentWrapper = manyWhoMount();
+        
+        const username = 'test@example.com';
+        const password = 'test';
+        
+        componentWrapper.instance().setState({
+            username,
+            password
+        });
+        
+        componentWrapper.instance().onSubmit();
+
+        expect(globalAny.window.manywho.ajax.login).toHaveBeenCalledWith(
+            props.loginUrl,
+            username,
+            password,
+            null,
+            null,
+            props.stateId,
+            tenantId,
+        );
+
+        expect(componentWrapper.state('loading')).toBe(null);
+        expect(componentWrapper.state('password')).toBe('');
+        expect(componentWrapper.state('faults')).toBe(mockFailWithObjectJSON.responseText);
     });
 
 });

--- a/js/components/login.tsx
+++ b/js/components/login.tsx
@@ -86,7 +86,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
                 this.setState({
                     loading: null,
                     password: '',
-                    faults: error.responseText,
+                    faults: typeof error.responseJSON === 'string' ? error.responseJSON : error.responseText,
                 });
             });
 

--- a/js/components/login.tsx
+++ b/js/components/login.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { findDOMNode } from 'react-dom';
+import { path } from 'ramda'; 
 import registeredComponents from '../constants/registeredComponents';
 import ILoginProps from '../interfaces/ILoginProps';
 import { getWait } from './wait';
@@ -86,7 +87,9 @@ class Login extends React.Component<ILoginProps, ILoginState> {
                 this.setState({
                     loading: null,
                     password: '',
-                    faults: typeof error.responseJSON === 'string' ? error.responseJSON : error.responseText,
+                    faults: typeof path(['responseJSON'], error) === 'string' ? error.responseJSON :
+                        manywho.utils.isNullOrWhitespace(path(['responseJSON', 'message'], error)) === false ? error.responseJSON.message : 
+                        path(['responseText'], error)
                 });
             });
 


### PR DESCRIPTION
jQuery fulfils responseJSON because we are always passing dataType of 'json' with all of our request (can be seen in ui-core connection.ts request function).
see https://api.jquery.com/jquery.ajax/#data-types for more info on responseJSON.

For errors, responseJSON should just resolve to a string, with the extra quotes parsed for us by jQuery.
For cases this doesn't work, we use responseText to ensure we always show a string.