### PR TITLE
FLOW-2389: Fix the catch is not a function error and clear files in state after message post

### DIFF
--- a/js/components/feed-input.tsx
+++ b/js/components/feed-input.tsx
@@ -67,11 +67,8 @@ class FeedInput extends React.Component<IFeedInputProps, IFeedInputState> {
         const textAreaElement: any = this.textareaRef.current;
 
         if (this.fileUploadRef && fileUploadElement && fileUploadElement.state.fileNames.length > 0) {
-
             deferred = fileUploadElement.onUpload();
-
         } else {
-
             deferred = $.Deferred();
             deferred.resolve();
         }
@@ -85,6 +82,7 @@ class FeedInput extends React.Component<IFeedInputProps, IFeedInputState> {
             textAreaElement.value = '';
             this.setState({
                 mentionedUsers: {},
+                attachedFiles: [], // empty attached files also so we don't try to send them again in the next message
             });
         });
     }
@@ -125,10 +123,10 @@ class FeedInput extends React.Component<IFeedInputProps, IFeedInputState> {
                     }
 
                     manywho.social.attachFiles(flowKey, formData, onProgress)
-                        .then(response => this.setState({ attachedFiles: response.files }))
-                        .catch((error) => {
+                        .done(response => this.setState({ attachedFiles: response.files }))
+                        .fail((xhr) => {
                             manywho.model.addNotification(flowKey, {
-                                message: error.message,
+                                message: `File upload failed! Error code: ${xhr.status} - ${xhr.statusText}`,
                                 position: 'center',
                                 type: 'danger',
                                 timeout: '0',


### PR DESCRIPTION
This PR:
- aims to fix the `react-dom-16.8.6.min.js:17 Uncaught TypeError: manywho.social.attachFiles(...).then(...).catch is not a function` error
- aims to fix the error that happens if we try to post a subsequent message after posting a message with an attachment